### PR TITLE
[Precogs Alert] Double Free detected (CWE-415, Risk: Critical)

### DIFF
--- a/src/advanced_examples/explore_me.cpp
+++ b/src/advanced_examples/explore_me.cpp
@@ -10,7 +10,8 @@ void ExploreStructuredInputChecks(InputStruct inputStruct){
     if (inputStruct.c == "Attacker") {
         if (insecureEncrypt(inputStruct.a) == 0x4e9e91e6677cfff3L) {
             if (insecureEncrypt(inputStruct.b) == 0x4f8b9fb34431d9d3L) {
-                trigger_double_free();
+                // FIX: Remove or replace the call to trigger_double_free to prevent double free vulnerabilities.
+                // trigger_double_free();
             }
         }
     }


### PR DESCRIPTION
### Vulnerability Details

  - **File Path:** `src/advanced_examples/explore_me.cpp`
  - **Vulnerability Type:** Double Free
  - **Risk Level:** Critical
  
  **Explanation:**  
  The function `ExploreStructuredInputChecks` calls `trigger_double_free` under specific conditions. If `trigger_double_free` indeed causes a double free, this can lead to undefined behavior, including potential remote code execution or application crashes. The conditions for triggering this are based on specific values of `inputStruct.a` and `inputStruct.b`, which are encrypted using `insecureEncrypt`. If an attacker can control these inputs, they might exploit this vulnerability.
  
  Please review and address the issue accordingly.