### PR TITLE
[Precogs Alert] Use of Freed Memory detected (CWE-416, Risk: High)

### DIFF
--- a/src/simple_examples/utils.cpp
+++ b/src/simple_examples/utils.cpp
@@ -22,10 +22,10 @@ std::string EncodeBase64(const std::string &input) {
   BIO_write(bio, input.c_str(), input.length());
   BIO_flush(bio);
   BIO_get_mem_ptr(bio, &bufferPtr);
+  std::string ret(bufferPtr->data, bufferPtr->length); // Use bufferPtr before freeing it
   BIO_set_close(bio, BIO_NOCLOSE);
   BIO_free_all(bio);
-  std::string ret(bufferPtr->data, bufferPtr->length);
 
-  BUF_MEM_free(bufferPtr);
+  BUF_MEM_free(bufferPtr); // Free bufferPtr after its data has been copied
   return ret;
 }


### PR DESCRIPTION
### Vulnerability Details

  - **File Path:** `src/simple_examples/utils.cpp`
  - **Vulnerability Type:** Use of Freed Memory
  - **Risk Level:** High
  
  **Explanation:**  
  The function uses the `bufferPtr` after it has been freed by `BUF_MEM_free(bufferPtr)`. This can lead to undefined behavior, including potential crashes or security vulnerabilities if the memory is reused or corrupted.
  
  Please review and address the issue accordingly.