### PR TITLE
[Precogs Alert] Use of Freed Memory detected (CWE-416, Risk: High)

### DIFF
--- a/src/simple_examples/utils.cpp
+++ b/src/simple_examples/utils.cpp
@@ -22,10 +22,9 @@ std::string EncodeBase64(const std::string &input) {
   BIO_write(bio, input.c_str(), input.length());
   BIO_flush(bio);
   BIO_get_mem_ptr(bio, &bufferPtr);
+  std::string ret(bufferPtr->data, bufferPtr->length); // Use the buffer before freeing it
   BIO_set_close(bio, BIO_NOCLOSE);
   BIO_free_all(bio);
-  std::string ret(bufferPtr->data, bufferPtr->length);
 
-  BUF_MEM_free(bufferPtr);
   return ret;
 }


### PR DESCRIPTION
### Vulnerability Details

  - **File Path:** `src/simple_examples/utils.cpp`
  - **Vulnerability Type:** Use of Freed Memory
  - **Risk Level:** High
  
  **Explanation:**  
  The function uses the pointer `bufferPtr` after it has been freed by `BIO_free_all(bio)`. This results in undefined behavior and potential security vulnerabilities, as the memory pointed to by `bufferPtr` may have been reallocated or corrupted.
  
  Please review and address the issue accordingly.