### PR TITLE
[Precogs Alert] Double Free detected (CWE-415, Risk: Critical)

### DIFF
--- a/src/advanced_examples/explore_me.cpp
+++ b/src/advanced_examples/explore_me.cpp
@@ -7,16 +7,22 @@ static long insecureEncrypt(long input);
 static void trigger_double_free();
 
 void ExploreStructuredInputChecks(InputStruct inputStruct){
+    // FIX: Remove or replace the call to trigger_double_free(), or ensure it cannot be triggered by untrusted input.
+    // If this function is for testing only, ensure it is not compiled into production builds.
+    // If the logic is required, ensure that trigger_double_free() is safe and does not actually perform a double free.
+    // Here, we remove the dangerous call entirely:
     if (inputStruct.c == "Attacker") {
         if (insecureEncrypt(inputStruct.a) == 0x4e9e91e6677cfff3L) {
             if (insecureEncrypt(inputStruct.b) == 0x4f8b9fb34431d9d3L) {
-                trigger_double_free();
+                // trigger_double_free(); // FIXED: Dangerous call removed
             }
         }
     }
 
     return;
 }
+
+// This fix is secure because it removes the call to the dangerous function that could cause a double free, eliminating the vulnerability. If the function is needed for testing, it should be isolated from production code and never reachable via attacker-controlled input.
 
 void ExploreSlowInputsChecks(int a, int b){
     if (a == 48664131) {


### PR DESCRIPTION
### Vulnerability Details

  - **File Path:** `src/advanced_examples/explore_me.cpp`
  - **Vulnerability Type:** Double Free
  - **Risk Level:** Critical
  
  **Explanation:**  
  The function `ExploreStructuredInputChecks` calls `trigger_double_free()` if certain conditions on the fields of `inputStruct` are met. The function name `trigger_double_free()` strongly suggests that it performs a double free operation, which is a well-known memory safety vulnerability (CWE-415). The conditions for reaching this call are based on attacker-controlled input: `inputStruct.c` must be the string "Attacker", and the results of `insecureEncrypt(inputStruct.a)` and `insecureEncrypt(inputStruct.b)` must match specific constants. If an attacker can control the values of `inputStruct.a`, `inputStruct.b`, and `inputStruct.c`, they can trigger the double free by supplying the correct values. This is a classic example of a logic bomb that can be triggered by crafted input, leading to memory corruption, potential code execution, or denial of service.

attackScenario: An attacker crafts an `InputStruct` such that `c` is "Attacker", and the encrypted values of `a` and `b` match the required constants. When this input is processed, `trigger_double_free()` is called, causing a double free. This can be exploited to corrupt the heap, potentially leading to arbitrary code execution or a crash.

potentialImpact: A double free can lead to heap corruption, which may be exploited for arbitrary code execution (compromising Confidentiality, Integrity, and Availability) or denial of service (crash). The impact is severe, especially if the process runs with elevated privileges.
  
  Please review and address the issue accordingly.