### PR TITLE
[Precogs Alert] Use-After-Free detected (CWE-416, Risk: Critical)

### DIFF
--- a/src/simple_examples/explore_me.cpp
+++ b/src/simple_examples/explore_me.cpp
@@ -42,9 +42,14 @@ static void trigger_global_buffer_overflow(const std::string &c) {
 }
 
 static void trigger_use_after_free() {
-  auto *buffer = static_cast<char *>(malloc(6));
+  auto *buffer = static_cast&lt;char *>(malloc(6));
+  if (!buffer) {
+    fprintf(stderr, "Memory allocation failed\n");
+    return;
+  }
   memcpy(buffer, "hello", 5);
   buffer[5] = '\0';
+  printf("%s\n", buffer); // FIX: Use buffer before freeing
   free(buffer);
-  printf("%s\n", buffer);
 }
+// FIX EXPLANATION: The buffer is now only used (printed) before it is freed, eliminating the use-after-free. Additionally, a NULL check is added after malloc for robustness.


### PR DESCRIPTION
### Vulnerability Details

  - **File Path:** `src/simple_examples/explore_me.cpp`
  - **Vulnerability Type:** Use-After-Free
  - **Risk Level:** Critical
  
  **Explanation:**  
  The function 'trigger_use_after_free' allocates a buffer, writes to it, frees it, and then immediately uses the freed pointer in a call to printf. This is a textbook use-after-free (UAF) vulnerability. After 'free(buffer);', the memory pointed to by 'buffer' is no longer owned by the program, and accessing it is undefined behavior. In practice, this can lead to information disclosure, program crashes, or even arbitrary code execution if an attacker can influence heap layout (e.g., via heap spraying or other heap manipulation techniques). The attack scenario is straightforward: if this function is called in a context where an attacker can control heap allocations or the contents of freed memory, they may be able to cause sensitive data to be printed, or even hijack control flow. The impact is severe: it can affect confidentiality (leak of memory contents), integrity (potential for memory corruption), and availability (crash).
  
  Please review and address the issue accordingly.