### PR TITLE
[Precogs Alert] Improper Input Validation detected (CWE-126: Buffer Over-read / CWE-131: Incorrect Calculation of Buffer Size, Risk: High)

### DIFF
--- a/src/state_example/key_management/key_management_1.c
+++ b/src/state_example/key_management/key_management_1.c
@@ -1,11 +1,22 @@
 #include "key_management_1.h"
 
-uint8_t *generate_random_bytes(uint8_t *buffer, uint8_t length) {
-  for (int i = 0; i < length; i++) {
+uint8_t *generate_random_bytes(uint8_t *buffer, size_t buffer_size, size_t length) {
+  // FIX: Validate input parameters
+  if (buffer == NULL) {
+    return NULL; // or handle error appropriately
+  }
+  if (length > buffer_size) {
+    return NULL; // or handle error appropriately
+  }
+  for (size_t i = 0; i &lt; length; i++) {
     buffer[i] = HSM_get_random_byte();
   }
   return buffer;
 }
+
+/*
+FIX EXPLANATION: The function now takes both the buffer pointer and its actual size (buffer_size) as arguments. It checks that the buffer is not NULL and that 'length' does not exceed 'buffer_size', preventing buffer overflows. This ensures safe memory access and robust error handling, following secure C coding best practices.
+*/
 
 void key_management_create_key(uint8_t *key, uint8_t length) {
   generate_random_bytes(key, length);


### PR DESCRIPTION
### Vulnerability Details

  - **File Path:** `src/state_example/key_management/key_management_1.c`
  - **Vulnerability Type:** Improper Input Validation
  - **Risk Level:** High
  
  **Explanation:**  
  The function 'generate_random_bytes' writes 'length' bytes to the memory pointed to by 'buffer' without validating that 'buffer' is non-NULL or that it points to a region of memory at least 'length' bytes long. If the caller provides a buffer that is too small or NULL, this will result in a buffer overflow or a segmentation fault, leading to undefined behavior, potential memory corruption, or even code execution. The function also does not check for integer overflow in 'length', though with uint8_t this is less likely to be a practical issue. The root cause is the lack of input validation and bounds checking on the buffer pointer and its size.

attackScenario: An attacker could call this function with a buffer smaller than 'length' or with a NULL pointer, causing a buffer overflow or crash. If this function is used in a security-sensitive context (e.g., generating cryptographic keys), this could be leveraged for denial of service or even arbitrary code execution if the overflow is exploitable.

potentialImpact: This can lead to memory corruption (Integrity), process crashes (Availability), and potentially arbitrary code execution (Confidentiality/Integrity/Availability).
  
  Please review and address the issue accordingly.